### PR TITLE
feat: deploy from CI on master push

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -123,7 +123,19 @@ jobs:
         run: yarn install --immutable
       - name: Install lftp
         run: sudo apt-get update && sudo apt-get install -y lftp
+      - name: Detect stale revision
+        id: revcheck
+        run: |
+          git fetch origin master --depth=1
+          remote_sha=$(git rev-parse origin/master)
+          if [ "$GITHUB_SHA" != "$remote_sha" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::This run is for $GITHUB_SHA but master HEAD is now $remote_sha; skipping deploy to avoid rolling back production."
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Deploy
+        if: steps.revcheck.outputs.stale != 'true'
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,7 @@
 name: CI Pipeline
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 
 env:
   NODE_VERSION: 24.x
@@ -99,3 +101,34 @@ jobs:
           path: |
             playwright-report
             test-results
+
+  deploy:
+    needs: [lint, editor-config, html-validate, markdown, security-audit, test]
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - run: corepack enable
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Install lftp
+        run: sudo apt-get update && sudo apt-get install -y lftp
+      - name: Deploy
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PASSWORD: ${{ secrets.DEPLOY_PASSWORD }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_VERIFY_URL: ${{ secrets.DEPLOY_VERIFY_URL }}
+        run: bash scripts/deploy.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.2.0 [2026-05-18]
+
+- Added CI deploy job (auto on master push + manual workflow_dispatch)
+- Deploy job gated by all lint/test jobs; only runs on refs/heads/master
+- Concurrency group prevents overlapping production deploys
+- Credentials sourced from GitHub Secrets, not the workflow file
+
 ## v4.1.0 [2026-05-18]
 
 - Added scripts/deploy.sh + yarn deploy (FTPS via lftp to OrangeHost)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,12 +83,14 @@ SSH/rsync was the original choice but OrangeHost support confirmed SSH is not av
 
 Manual run: `gh workflow run "CI Pipeline" --ref master` (or the "Run workflow" button on the Actions tab).
 
-Required GitHub Secrets (Settings → Secrets and variables → Actions → New repository secret):
+GitHub Secrets (Settings → Secrets and variables → Actions → New repository secret):
 
-- `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_PASSWORD`, `DEPLOY_PATH` — same values as in your local `.env.deploy`
-- `DEPLOY_VERIFY_URL` — public site URL; the post-deploy smoke check fails the job on non-2xx/3xx
+- Required: `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_PASSWORD`, `DEPLOY_PATH` — same values as in your local `.env.deploy`
+- Optional: `DEPLOY_VERIFY_URL` — public site URL; when set, the post-deploy smoke check fails the job on non-2xx/3xx. When unset, the check is skipped and the deploy job stays green based on the `lftp` exit status alone.
 
-All five+1 are referenced as `${{ secrets.X }}` only inside the `Deploy` step's `env:` block; they never appear in the workflow file as plain text. Rotation: change the FTP password in cPanel, update both `.env.deploy` and the `DEPLOY_PASSWORD` secret.
+All are referenced as `${{ secrets.X }}` only inside the `Deploy` step's `env:` block; they never appear in the workflow file as plain text. Rotation: change the FTP password in cPanel, update both `.env.deploy` and the `DEPLOY_PASSWORD` secret.
+
+A "Detect stale revision" step runs before `Deploy`: it compares `$GITHUB_SHA` against `origin/master` and skips the upload (logging a `::notice::`) if a newer commit has overtaken this run. The `concurrency` group alone doesn't enforce push order — it serialises by ready-time — so without this guard a slower-tested older commit could deploy after a faster-tested newer one and roll production back.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,11 +77,24 @@ SSH/rsync was the original choice but OrangeHost support confirmed SSH is not av
 - `lftp mirror --reverse --delete` from `build/` to `$DEPLOY_PATH/` over **forced FTPS** (`ftp:ssl-force true`, `ftp:ssl-protect-data true`, `ssl:verify-certificate true` — connection aborts if the server can't do TLS or has a bad cert). Excludes (anchored regex, top-level only): `^\.well-known/`, `^cgi-bin/`, `^\.htaccess$`, `^\.ftpquota$`. These are cPanel/Let's-Encrypt-managed; `--delete` would otherwise wipe them every deploy. Anchored on purpose — same-named files deeper in the tree (e.g. `dm/.ftpquota` from a stale FTP user's dir) are not protected and get cleaned up.
 - If `DEPLOY_VERIFY_URL` is set, does a `curl` smoke check at the end and exits non-zero on non-2xx/3xx; otherwise prints "Skipping verification".
 
+### CI deploy (GitHub Actions)
+
+`.github/workflows/pipeline.yml` contains a `deploy` job that runs the same `scripts/deploy.sh` on every push to `master` (and via manual `workflow_dispatch`). It `needs:` every lint/test job — a red CI blocks the deploy. The job is also gated by `if: github.ref == 'refs/heads/master'`, so pushes to feature branches never touch production. A `concurrency: deploy-production` group serialises overlapping runs (the second waits for the first; nothing is cancelled mid-upload).
+
+Manual run: `gh workflow run "CI Pipeline" --ref master` (or the "Run workflow" button on the Actions tab).
+
+Required GitHub Secrets (Settings → Secrets and variables → Actions → New repository secret):
+
+- `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_PASSWORD`, `DEPLOY_PATH` — same values as in your local `.env.deploy`
+- `DEPLOY_VERIFY_URL` — public site URL; the post-deploy smoke check fails the job on non-2xx/3xx
+
+All five+1 are referenced as `${{ secrets.X }}` only inside the `Deploy` step's `env:` block; they never appear in the workflow file as plain text. Rotation: change the FTP password in cPanel, update both `.env.deploy` and the `DEPLOY_PASSWORD` secret.
+
 ### Security
 
-The repo is public; `scripts/deploy.sh` and `.env.deploy.example` must stay free of usernames, hostnames, ports, or absolute paths. Real values live only in `.env.deploy` on disk.
+The repo is public; `scripts/deploy.sh` and `.env.deploy.example` must stay free of usernames, hostnames, ports, or absolute paths. Real values live only in `.env.deploy` on disk (locally) and in GitHub Secrets (CI).
 
-`DEPLOY_PASSWORD` passes through `lftp` argv and is briefly visible in `ps` on the local machine — acceptable on a single-user dev box, mitigated by using a dedicated path-restricted FTP account. To rotate: change the password in cPanel → FTP Accounts and update `.env.deploy`.
+`DEPLOY_PASSWORD` passes through `lftp` argv. Locally it's briefly visible in `ps` on the dev machine; in CI it's shielded by GitHub's job-level secret masking (any literal match of the secret in logs gets replaced with `***`). Both contexts are mitigated by using a dedicated path-restricted FTP account: a leaked password can only overwrite the public site, recoverable via `yarn deploy` from git. To rotate: change the password in cPanel → FTP Accounts, update `.env.deploy` and the GitHub `DEPLOY_PASSWORD` secret.
 
 ## HTML validation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-markov",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "Dmitry Markov",
   "description": "Dmitry Markov's CV",
   "bugs": {


### PR DESCRIPTION
## Summary

Wires `scripts/deploy.sh` (shipped in v4.1.0) into GitHub Actions. From this PR onwards, every successful build on `master` auto-publishes to OrangeHost; the same workflow can also be triggered manually from the Actions tab.

- New `deploy` job in `pipeline.yml`: `needs:` every lint/test job, `if: github.ref == 'refs/heads/master'`, `permissions: contents: read`
- `concurrency: deploy-production` (no `cancel-in-progress`) serialises overlapping pushes — second waits, no mid-upload cancel
- Installs `lftp` via apt on `ubuntu-latest`, then invokes the same `bash scripts/deploy.sh` we use locally
- Credentials passed only through the `Deploy` step's `env:` block, sourced from repository secrets; never appear in plain text in the workflow file
- Adds `workflow_dispatch:` trigger for manual runs
- Version bumped 4.1.0 → 4.2.0

## Action required before merge

**Add these secrets** (Settings → Secrets and variables → Actions → New repository secret):

- `DEPLOY_HOST` — same as local `.env.deploy`
- `DEPLOY_PORT`
- `DEPLOY_USER`
- `DEPLOY_PASSWORD`
- `DEPLOY_PATH`
- `DEPLOY_VERIFY_URL` (optional; without it the post-deploy smoke check is skipped)

If secrets are missing when this PR merges, the `deploy` job will fail fast at the `${VAR:?}` guards in `scripts/deploy.sh` — production is not at risk of partial uploads.

## Test plan

- [x] `yaml.safe_load` validates the workflow file
- [x] `yarn markdown` clean
- [x] Local `yarn deploy` already proven in v4.1.0 (PR #637)
- [ ] First CI deploy after merge — verify Actions run for `deploy` is green, site updates to v4.2.0
- [ ] `gh workflow run "CI Pipeline" --ref master` — confirms manual trigger works
🤖 Generated with [Claude Code](https://claude.com/claude-code)