### PR TITLE
feat: add Lighthouse CI gate

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -78,6 +78,26 @@ jobs:
         run: yarn install --immutable
       - run: yarn security-audit
 
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - run: corepack enable
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn build
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@12.1.0
+        with:
+          configPath: ./.lighthouserc.json
+          uploadArtifacts: true
+
   test:
     runs-on: ubuntu-latest
     container:
@@ -103,7 +123,7 @@ jobs:
             test-results
 
   deploy:
-    needs: [lint, editor-config, html-validate, markdown, security-audit, test]
+    needs: [lint, editor-config, html-validate, lighthouse, markdown, security-audit, test]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,25 @@
+{
+  "ci": {
+    "collect": {
+      "startServerCommand": "yarn preview",
+      "startServerReadyPattern": "Local",
+      "startServerReadyTimeout": 30000,
+      "url": ["http://127.0.0.1:4444/"],
+      "numberOfRuns": 3,
+      "settings": {
+        "chromeFlags": "--no-sandbox --headless=new"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -7,7 +7,8 @@
       "url": ["http://127.0.0.1:4444/"],
       "numberOfRuns": 3,
       "settings": {
-        "chromeFlags": "--no-sandbox --headless=new"
+        "chromeFlags": "--no-sandbox --headless=new",
+        "skipAudits": ["is-on-https"]
       }
     },
     "assert": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v4.3.0 [2026-05-18]
+
+- Added Lighthouse CI job to pipeline.yml (treosh/lighthouse-ci-action)
+- Runs against yarn preview, mobile profile, 3 runs averaged
+- Asserts >=0.9 on all four categories (perf, a11y, best-practices, seo)
+- Added to deploy job needs:; failed Lighthouse blocks production push
+- Reports uploaded as workflow artifacts on every run
+
 ## v4.2.0 [2026-05-18]
 
 - Added CI deploy job (auto on master push + manual workflow_dispatch)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,18 @@ The repo is public; `scripts/deploy.sh` and `.env.deploy.example` must stay free
 
 `DEPLOY_PASSWORD` passes through `lftp` argv. Locally it's briefly visible in `ps` on the dev machine; in CI it's shielded by GitHub's job-level secret masking (any literal match of the secret in logs gets replaced with `***`). Both contexts are mitigated by using a dedicated path-restricted FTP account: a leaked password can only overwrite the public site, recoverable via `yarn deploy` from git. To rotate: change the password in cPanel → FTP Accounts, update `.env.deploy` and the GitHub `DEPLOY_PASSWORD` secret.
 
+## Lighthouse CI
+
+`.github/workflows/pipeline.yml` runs a `lighthouse` job in parallel with the other lint jobs and gates the `deploy` job on it. Config lives in `.lighthouserc.json` at the repo root.
+
+- Server: `yarn preview` started by the action (same pattern Playwright uses) — checks the production build before any FTPS upload.
+- Profile: mobile-only with `--headless=new`; desktop scores equal-or-higher than mobile, so a passing mobile run implies desktop also passes. Adding a desktop run would double CI time without changing the gating outcome.
+- 3 runs averaged (`numberOfRuns: 3`) — Lighthouse fluctuates ±1–2 points per category run-to-run; averaging keeps the gate stable.
+- Thresholds (`assert.assertions`): **>=0.9** on `performance`, `accessibility`, `best-practices`, `seo`. Set as `error` level — below 0.9 fails the job and blocks deploy. Current baseline (measured against prod v4.2.0): perf 99, a11y 97, best-practices 100, seo 100 — well above the floor.
+- Reports: `uploadArtifacts: true` saves the JSON + HTML report on every run; `upload.target: temporary-public-storage` posts a Lighthouse-CI public URL in the action log for quick visual diff.
+
+The mobile a11y score is 97, not 100, because of one real audit failure: `landmark-one-main` (`<main>` element missing in `src/index.html`). Above the threshold, so it doesn't fail CI — worth fixing in a separate small PR.
+
 ## HTML validation
 
 `.htmlvalidate.json` extends `html-validate:recommended` but overrides two stylistic rules to align with Prettier (the source of truth for formatting): `doctype-style` accepts `lowercase` (Prettier 3 always lowercases `<!doctype html>`) and `void-style` accepts `selfclose` (Prettier outputs `<meta />`). Without these overrides, the formatter and the linter would chase each other forever. Substantive rules (alt text, attribute names, deprecated tags, accessibility) stay strict. The CI `html-validate` job no longer needs `actions/setup-java` — pure JS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ The repo is public; `scripts/deploy.sh` and `.env.deploy.example` must stay free
 - Server: `yarn preview` started by the action (same pattern Playwright uses) — checks the production build before any FTPS upload.
 - Profile: mobile-only with `--headless=new`; desktop scores equal-or-higher than mobile, so a passing mobile run implies desktop also passes. Adding a desktop run would double CI time without changing the gating outcome.
 - 3 runs averaged (`numberOfRuns: 3`) — Lighthouse fluctuates ±1–2 points per category run-to-run; averaging keeps the gate stable.
+- `skipAudits: ["is-on-https"]` — `yarn preview` serves over HTTP on localhost, and Lighthouse v12 stopped exempting localhost from `is-on-https`. Without the skip, best-practices drops to 0.82 (single audit, weight 5/32). Production is on HTTPS and scores 1.00 regardless.
 - Thresholds (`assert.assertions`): **>=0.9** on `performance`, `accessibility`, `best-practices`, `seo`. Set as `error` level — below 0.9 fails the job and blocks deploy. Current baseline (measured against prod v4.2.0): perf 99, a11y 97, best-practices 100, seo 100 — well above the floor.
 - Reports: `uploadArtifacts: true` saves the JSON + HTML report on every run; `upload.target: temporary-public-storage` posts a Lighthouse-CI public URL in the action log for quick visual diff.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,6 @@
 # TODO
 
-- [x] local dev
-- [ ] publish action
 - [ ] dark/light mode css switcher
-- [x] dockerized screenshot test runner
-- [ ] add Lighthouse check to pipeline
 - [ ] add semantic versioning tooling
 - [ ] PWA optimizations
 - [ ] add main landmark to src/index.html for a11y

--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,5 @@
 - [ ] add Lighthouse check to pipeline
 - [ ] add semantic versioning tooling
 - [ ] PWA optimizations
+- [ ] add main landmark to src/index.html for a11y
 - [ ] Add Allthings/Oxygen zeugnis docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cv-markov",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "author": "Dmitry Markov",
   "description": "Dmitry Markov's CV",
   "bugs": {


### PR DESCRIPTION
## Summary

Adds a Lighthouse CI job to `pipeline.yml` and wires it into the deploy gate. Any regression below `>=0.9` on performance, accessibility, best-practices, or SEO will fail CI and block the production push.

- `treosh/lighthouse-ci-action@12.1.0`, runs against `yarn preview` (same harness Playwright uses)
- Mobile profile only — desktop scores equal-or-higher; running both would double CI time without changing the gate outcome
- 3 averaged runs (`numberOfRuns: 3`) to absorb Lighthouse's ±1-2 point per-category jitter
- Reports uploaded as workflow artifacts every run; a `temporary-public-storage` URL is also posted in the action log
- Added to the `deploy` job's `needs:` — a failing Lighthouse blocks production
- Version 4.2.0 → 4.3.0

## Baseline (measured against prod v4.2.0)

| | Performance | Accessibility | Best practices | SEO |
|---|---|---|---|---|
| Mobile | 99 | 97 | 100 | 100 |
| Desktop | 99 | 97 | 100 | 100 |

Comfortable buffer above the 0.9 floor on every category.

## Known a11y dip (out of scope here)

Mobile a11y is 97, not 100, because of one real audit failure: `landmark-one-main` (`<main>` element missing in `src/index.html`). Above the threshold, so doesn't fail CI. Worth a separate small PR.

## Test plan

- [x] `yaml.safe_load` validates pipeline.yml
- [x] `python3 -m json.tool < .lighthouserc.json` clean
- [x] `yarn markdown` clean
- [x] Baseline scores collected locally (lighthouse mobile + desktop against prod)
- [ ] CI green on this PR — confirms the job runs, `yarn preview` starts, treosh action installs Chrome correctly, thresholds match measured baseline
🤖 Generated with [Claude Code](https://claude.com/claude-code)