### PR TITLE
chore: bump lighthouse-ci-action to 12.6.2 (Node 24)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@12.1.0
+        uses: treosh/lighthouse-ci-action@12.6.2
         with:
           configPath: ./.lighthouserc.json
           uploadArtifacts: true


### PR DESCRIPTION
## Summary

I pinned `treosh/lighthouse-ci-action@12.1.0` in #639 — the first stable release on the v12 branch (June 2024). 12.6.2 (March 2026) is the current head and is the version we want:

- Its action runtime is Node 24, which silences the GitHub Actions deprecation warning ("Node.js 20 actions are deprecated... forced to Node.js 24 by default starting June 2nd, 2026")
- Bundled `@lhci/cli` upgraded to 0.15.0 (no breaking changes to our `.lighthouserc.json` schema)

No version bump in `package.json` — same shape as a dep update, not a feature.

## Test plan

- [x] yaml.safe_load validates pipeline.yml
- [ ] CI green on this PR — confirms the bumped action still runs against `yarn preview` and our existing assertions pass
- [ ] No more "Node.js 20 actions are deprecated" warning in the lighthouse step log
🤖 Generated with [Claude Code](https://claude.com/claude-code)