### PR TITLE
chore: disable yarn npmMinimalAgeGate to unblock Renovate PRs

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,10 @@ nodeLinker: node-modules
 defaultSemverRangePrefix: ""
 
 enableGlobalCache: false
+
+# Yarn 4.15.0 introduced npmMinimalAgeGate (default 1d): it refuses to resolve
+# any version published less than a day ago, surfaced as a misleading
+# "YN0016: ... are quarantined" error. That breaks every Renovate PR for a
+# fresh version — both Renovate's own yarn.lock update and CI's
+# `yarn install --immutable`. Disable the gate to restore the prior behaviour.
+npmMinimalAgeGate: "0"


### PR DESCRIPTION
## Problem

Every open PR fails CI with the same root cause: `yarn install --immutable` aborts at the resolution step with a misleading message:

```
YN0016: lint-staged@npm:17.0.7: All versions satisfying "17.0.7" are quarantined
```

This is **not** an npm-registry quarantine (no such flag exists on npmjs.org for these versions). It is a new Yarn feature: the **Yarn 4.14.1 → 4.15.0** bump (commit f0a2706) introduced `npmMinimalAgeGate` with a **default of `1d`**, which refuses to resolve any version published less than a day ago.

The effect hits every Renovate PR for a freshly published version, two ways:

1. Renovate cannot regenerate `yarn.lock` → `renovate/artifacts` check fails ("Artifact file update failure"), leaving the branch with `package.json` on the new version but `yarn.lock` on the old one.
2. CI `yarn install --immutable` fails on resolution — either because the version is younger than 1 day, or because the stale lockfile wants to update and `--immutable` forbids it. Install is the first step of every job, so **all** jobs go red.

## Fix

Set `npmMinimalAgeGate: "0"` in `.yarnrc.yml` to restore the pre-4.15.0 behaviour.

Verified locally: with the gate disabled, even a 5-hour-old `lint-staged@17.0.7` resolves cleanly, and `yarn install --immutable` passes on this project.

Once merged, the open Renovate PRs rebase onto master, Renovate regenerates the broken lockfiles, and they go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)